### PR TITLE
Extract event policy to a factory

### DIFF
--- a/domain/src/main/kotlin/com/yonatankarp/domain/entity/Event.kt
+++ b/domain/src/main/kotlin/com/yonatankarp/domain/entity/Event.kt
@@ -1,12 +1,9 @@
 package com.yonatankarp.domain.entity
 
-import com.yonatankarp.domain.policy.RegexEventParser
-import com.yonatankarp.domain.policy.SplitEventParser
+import com.yonatankarp.domain.policy.EventParserFactory
 import com.yonatankarp.domain.valueobject.Activity
 import com.yonatankarp.domain.valueobject.EventId
 import com.yonatankarp.domain.valueobject.ParsePolicyType
-import com.yonatankarp.domain.valueobject.ParsePolicyType.REGEX
-import com.yonatankarp.domain.valueobject.ParsePolicyType.SPLIT
 import com.yonatankarp.domain.valueobject.Protocol
 import java.time.OffsetTime
 
@@ -22,11 +19,6 @@ data class Event(
         fun parsedEvent(
             unparsedEvent: String,
             policy: ParsePolicyType,
-        ): Event {
-            return when (policy) {
-                REGEX -> RegexEventParser().parseEvent(unparsedEvent)
-                SPLIT -> SplitEventParser().parseEvent(unparsedEvent)
-            }
-        }
+        ): Event = EventParserFactory.eventParser(policy).parseEvent(unparsedEvent)
     }
 }

--- a/domain/src/main/kotlin/com/yonatankarp/domain/entity/Router.kt
+++ b/domain/src/main/kotlin/com/yonatankarp/domain/entity/Router.kt
@@ -11,7 +11,7 @@ data class Router(
     var networkSwitch: Switch,
 ) {
     fun addNetworkToSwitch(network: Network) {
-        networkSwitch = networkSwitch.addNetwork(network) // FIXME: see if I can use copy instead
+        networkSwitch = networkSwitch.addNetwork(network)
     }
 
     fun createNetwork(

--- a/domain/src/main/kotlin/com/yonatankarp/domain/policy/EventParserFactory.kt
+++ b/domain/src/main/kotlin/com/yonatankarp/domain/policy/EventParserFactory.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.domain.policy
+
+import com.yonatankarp.domain.valueobject.ParsePolicyType
+
+object EventParserFactory {
+    fun eventParser(policy: ParsePolicyType) =
+        when (policy) {
+            ParsePolicyType.REGEX -> RegexEventParser()
+            ParsePolicyType.SPLIT -> SplitEventParser()
+        }
+}

--- a/domain/src/test/kotlin/com/yonatankarp/domain/policy/EventParserFactoryTest.kt
+++ b/domain/src/test/kotlin/com/yonatankarp/domain/policy/EventParserFactoryTest.kt
@@ -1,0 +1,34 @@
+package com.yonatankarp.domain.policy
+
+import com.yonatankarp.domain.valueobject.ParsePolicyType
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertEquals
+
+class EventParserFactoryTest {
+    @ParameterizedTest(name = "should return the correct parser for policy {0}")
+    @MethodSource("testCases")
+    fun `should return the correct parser`(
+        parsePolicy: ParsePolicyType,
+        clazz: Class<EventParser>,
+    ) {
+        // Given
+        val policy = parsePolicy
+
+        // When
+        val eventParser = EventParserFactory.eventParser(policy)
+
+        // Then
+        assertEquals(clazz, eventParser::class.java)
+    }
+
+    companion object {
+        @JvmStatic
+        fun testCases() =
+            listOf(
+                Arguments.of(ParsePolicyType.SPLIT, SplitEventParser::class.java),
+                Arguments.of(ParsePolicyType.REGEX, RegexEventParser::class.java),
+            )
+    }
+}


### PR DESCRIPTION


# Purpose

This commit extracts the event parsing policy into a factory to maintain the Open/Close principle. That means that from now on when a new policy is introduced, the event should not be amended, but only the factory.

---

## Related Chapter

- Chapter 2

---

